### PR TITLE
setup gemini cli(optional)

### DIFF
--- a/.devcontainer/commands/initializeCommand.sh
+++ b/.devcontainer/commands/initializeCommand.sh
@@ -28,6 +28,9 @@ else
     log -w "GitHub CLI is not installed. Skipping authentication."
 fi
 
+# Gemini CLI用のワークスペースの作成
+mkdir -p "$DCDIR/tmp/.gemini/tmp"
+
 LSCRIPT="$CMDDIR/initializeCommand.local.sh"
 if [ -x "$LSCRIPT" ]; then
     log "Run local script: $(basename $LSCRIPT)"

--- a/.devcontainer/commands/postCreateCommand.local.sh.example
+++ b/.devcontainer/commands/postCreateCommand.local.sh.example
@@ -1,25 +1,32 @@
 #!/bin/bash
 
-# script for customize local environment.
+# postCreateCommand をカスタマイズする場合は postCreateCommand.local.sh を作成して実行権限を付与します
+# 引数としてdevcontainer.jsonで指定したユーザー名が渡されます
 
 user=${1:?not set user}
 
-# ホストから連携されるgpg署名に $user で指定された公開鍵があることを前提とする
-# また、その公開鍵にはメールアドレスが設定されていることを前提とする 
-signkey=$(gpg --list-keys --with-colons $GPG_NAME | grep '^pub' | cut -d: -f5)
-mail=$(gpg --list-keys --with-colons $signkey | awk -F: '/^uid:/ {print $10}' | cut -d'<' -f2 | cut -d'>' -f1)
+log "Start custom post create"
+log "  container user : $user"
 
+# 以下のサンプルではコンテナに対してgit-subのインストールを行っています
 cmd="$(cat << CMD
-git config --global user.name $GPG_NAME
-git config --global user.email $mail
-git config --global user.signingkey $signkey
-git config --global commit.gpgsign true
-git config --global tag.gpgsign true
-
-curl https://github.com/web-flow.gpg | gpg --import
+(
+    cd $DIR
+    ./install.sh --bash
+    ./install-alias.sh
+    ./refresh-completions.sh
+)
 CMD
 )"
 
-echo run postCommand.local.sh
 echo "$cmd"
 eval "$cmd"
+
+# gemini CLIを使う場合は以下のコメントを解除します
+# デフォルトでは一度インストールしたらコンテナ再構築後も永続化されます
+# if command -v gemini &> /dev/null; then
+#     log "Gemini CLI is already installed."
+# else
+#     log "Gemini CLI is not installed. Installing..."
+#     npm install -g @google/gemini-cli
+# fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
 	"postCreateCommand": "./.devcontainer/commands/postCreateCommand.sh vscode",
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
 	"mounts": [
+		"source=${localWorkspaceFolder}/.devcontainer/tmp/.gemini,target=/home/vscode/.gemini,type=bind,consistency=cached",
 		"source=node_global_modules_vol,target=/home/vscode/.global_node_modules,type=volume"
 	],
 	"workspaceFolder": "/workspace",


### PR DESCRIPTION
オプショナルでGemini CLIをインストールできるようにしました

- gemini CLIのインストールは重いので、すでにインストール済であればスキップ
- .devconainer/tmp/.geminiにワークスペースをマウントで複製
    - 認証情報や設定などはここに保存される