### PR TITLE
Fix git latest

### DIFF
--- a/git-latest
+++ b/git-latest
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/bash -eu
+
+set -o pipefail
 
 # git latest
 #   指定したブランチの最新を取得する
@@ -25,11 +27,13 @@ git branch -r | awk '{ print $1 }' | grep -E "^origin/$branch$" > /dev/null || {
 }
 
 # HEADからの差分があれば一旦stashする
-(git diff --name-only; git diff --cached --name-only) | grep . > /dev/null
+set +e
+git status --porcelain | grep -E '^[ MARC][MDR]' > /dev/null
 uncommitted=$?
 if [ $uncommitted -eq 0 ] ; then
     git stash
 fi
+set -e
 
 # pullだとずれていると使えないのでresetする
 # Note: 以前は git branch -D && git switch で強制的に最新を取得していたが、


### PR DESCRIPTION
- common.shの中で -eu したことで差分なしのときに途中のgrep失敗で停止する不具合の修正
- ついでにgit-latest自体にも-euをつけるようにした

----

以下AIによるサマリー

このプルリクエストは、`git-latest` スクリプトを更新し、stash 操作を実行する前の未コミット変更の処理を改善しました。この変更により、`git status --porcelain` を使用して未コミット変更を検出し、エラー処理を一時的に無効化することで、堅牢性が向上します。

未コミット変更検出の機能強化:

* スクリプトを更新し、`git status --porcelain` で正規表現 (`^[ MARC][MDR]`) を使用することで、未コミット変更をより正確に検出できるようになりました。これは、`git diff` と `git diff --cached` を使用していた従来の手法に代わるものです。
* 検出プロセス中にエラー処理を一時的に無効化 (`set +e`) し、スクリプトがエラーによって途中で終了しないようにしました。その後、エラー処理を再度有効化 (`set -e`) して、通常のエラー処理動作に戻しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * エラーや未定義変数が発生した際にスクリプトが即座に終了するよう改善しました。
  * 未コミットの変更検出方法を見直し、より正確に変更を検出できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->