### PR TITLE
Fix: unbound variable in git-last

### DIFF
--- a/.github/instructions/git.instructions.md
+++ b/.github/instructions/git.instructions.md
@@ -29,7 +29,7 @@ git からの補完を効かせるために、サブコマンドとして提供�
 set -euo pipefail
 
 DIR=$(cd $(dirname ${BASH_SOURCE}); pwd)
-. $DIR/common.sh
+. "$DIR/common.sh"
 
 .... ここから個別の処理を書き始める
 ```

--- a/git-last
+++ b/git-last
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
 DIR=$(cd $(dirname ${BASH_SOURCE}); pwd)
 . $DIR/common.sh || exit 1
 
-CNT="$1"
+CNT="${1:-}"
 
 # オプションは ハイフン + 数字(0〜999)
 # 未指定時は -0 と同義

--- a/git-last
+++ b/git-last
@@ -4,13 +4,10 @@ set -euo pipefail
 DIR=$(cd $(dirname ${BASH_SOURCE}); pwd)
 . $DIR/common.sh || exit 1
 
-CNT="${1:-}"
+CNT="${1:-0}"
 
 # オプションは ハイフン + 数字(0〜999)
-# 未指定時は -0 と同義
-if [ -z "$CNT" ] ; then
-    CNT=0
-elif expr "$CNT" : '^-[0-9]\{1,3\}$' > /dev/null ; then
+if expr "$CNT" : '^-[0-9]\{1,3\}$' > /dev/null ; then
     CNT="${CNT/-/}"
 else
     err "invalid args: $*"

--- a/git-last
+++ b/git-last
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 DIR=$(cd $(dirname ${BASH_SOURCE}); pwd)
-. $DIR/common.sh || exit 1
+. "$DIR/common.sh"
 
 CNT="${1:-0}"
 


### PR DESCRIPTION
## 概要

このプルリクエストは、「git-last」スクリプト内で発生していた未束縛変数（unbound variable）エラーの修正を行います。引数の参照時に未定義の場合でもエラーとならないようにパラメータの扱いを安全にし、スクリプトの安定性を向上させました。

## 変更内容
- 変数参照時に `${1:-}` 形式を用いることで、未指定時のエラーを防止
- `set -euo pipefail` を追加し、スクリプト全体の安全性を強化

## 動作確認
- 引数あり／なしの両パターンで `git-last` コマンドを実行し、エラーが発生しないことを確認

## 関連Issue
- 該当なし

## 補足
- 特にありません

----

<details>
<summary>AIがレビューする際に遵守するべき指示</summary>

- コメントは日本語で記述してください。
- レビューの際は、変更点を明確に把握できるように、具体的なコードの変更内容を示してください。

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 引数のエラーハンドリングが強化され、より安全にスクリプトが動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->